### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,11 @@ export default {
           }
         },
         {
-          rel: 'modulepreload',
-          type: undefined,
           match: /lazy.[a-z-0-9]*.(js)$/,
+          attributes: {
+            rel: 'modulepreload',
+            type: undefined,
+          }
         }
       ],
       injectTo: 'head-prepend'


### PR DESCRIPTION
Additional parameters besides match need to be under an `attributes` field.

I was checking out this library and wondered why I wasn't seeing modulepreload show up when following the readme.

This change fixed it for me.